### PR TITLE
Point project source links to GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,7 +106,7 @@
           <p>Prompt builder with reusable patterns and an audit‑friendly preview.</p>
           <div class="actions">
             <a class="btn" href="https://astika327-dev.github.io/promptcraft/" target="_blank" rel="noopener">Live</a>
-            <a class="btn ghost" href="https://astika327-dev.github.io/promptcraft/" target="_blank" rel="noopener">Source</a>
+            <a class="btn ghost" href="https://github.com/astika327-dev/promptcraft" target="_blank" rel="noopener">Source</a>
           </div>
         </article>
         <article class="card project">
@@ -116,8 +116,8 @@
           </div>
           <p>Unified SOP/QA kit: checklists, incident notes, and audit templates.</p>
           <div class="actions">
-            <a class="btn" href=" https://astika327-dev.github.io/opsplaybook-hospitality/" target="_blank" rel="noopener">Live</a>
-            <a class="btn ghost" href=" https://astika327-dev.github.io/opsplaybook-hospitality/" target="_blank" rel="noopener">Source</a>
+            <a class="btn" href="https://astika327-dev.github.io/opsplaybook-hospitality/" target="_blank" rel="noopener">Live</a>
+            <a class="btn ghost" href="https://github.com/astika327-dev/opsplaybook-hospitality" target="_blank" rel="noopener">Source</a>
           </div>
         </article>
         <article class="card project">


### PR DESCRIPTION
## Summary
- update project cards to point "Source" buttons at their GitHub repositories
- clean up href values so live and source buttons lead to distinct destinations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbbda70fe48323acb84501d520ae5b