### PR TITLE
Improve mobile nav accessibility

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -5,9 +5,30 @@
   const toggle = document.querySelector('.nav-toggle');
   const links  = document.getElementById('nav-links');
   if (toggle && links){
+    const closeMenu = () => {
+      links.classList.remove('open');
+      toggle.setAttribute('aria-expanded', 'false');
+    };
+
     toggle.addEventListener('click', () => {
       const open = links.classList.toggle('open');
       toggle.setAttribute('aria-expanded', String(open));
+    });
+
+    links.querySelectorAll('a').forEach(anchor => {
+      anchor.addEventListener('click', () => {
+        if (links.classList.contains('open')) closeMenu();
+      });
+    });
+
+    document.addEventListener('keydown', event => {
+      if (event.key === 'Escape' && links.classList.contains('open')) closeMenu();
+    });
+
+    document.addEventListener('click', event => {
+      if (!links.classList.contains('open')) return;
+      if (event.target instanceof Node && (links.contains(event.target) || toggle.contains(event.target))) return;
+      closeMenu();
     });
   }
 


### PR DESCRIPTION
## Summary
- close the mobile navigation when a menu link is selected and keep aria-expanded in sync
- add Escape key and outside click handlers so the menu closes consistently

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cbbe2e42e48323b9e300aa5d165e6a