### PR TITLE
Improve typography spacing and line height

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -19,7 +19,12 @@ body{
   color:var(--ink);
   background: radial-gradient(1200px 600px at 50% -20%, #102040 0%, transparent 60%), var(--bg);
   font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  line-height:1.6;
 }
+
+h1{line-height:1.18;}
+h2{line-height:1.3;}
+h3{line-height:1.35;}
 
 /* Header / Navbar */
 .header{position:sticky;top:0;z-index:50;background:linear-gradient(180deg, rgba(11,18,32,.9), rgba(11,18,32,.6));backdrop-filter:saturate(1.2) blur(6px);border-bottom:1px solid var(--line)}
@@ -34,13 +39,14 @@ body{
 
 /* Sections / layout */
 .section{max-width:1140px;margin:0 auto;padding: clamp(20px, 5vw, 48px) 16px;border-top:1px solid var(--line)}
-.section h2{font-size:clamp(1.2rem,2.6vw,1.8rem);margin:0 0 14px}
-.bullets{margin:10px 0 0 0;padding-left:18px;color:var(--muted)}
+.section h2{font-size:clamp(1.2rem,2.6vw,1.8rem);margin:0 0 16px}
+.bullets{margin:12px 0 0 0;padding-left:18px;color:var(--muted)}
+.bullets li+li{margin-top:8px}
 
 /* Hero */
 .hero{min-height:100vh;max-width:1140px;margin:0 auto;padding: clamp(40px, 8vw, 120px) 16px;display:grid;align-content:center;gap:16px}
 .hero-title{font-size: clamp(2rem, 5vw, 3.2rem);line-height:1.15;margin:0}
-.hero-sub{color:var(--muted);max-width:820px}
+.hero-sub{color:var(--muted);max-width:820px;margin:0}
 .hero-actions{display:flex;gap:10px;flex-wrap:wrap}
 .hero-meta{color:var(--muted);opacity:.9;margin-top:8px}
 
@@ -50,7 +56,11 @@ body{
 .cards.three{grid-template-columns:repeat(3, minmax(0,1fr))}
 .card{background: linear-gradient(180deg, var(--card), var(--card-2));border:1px solid var(--line);border-radius:16px;box-shadow:var(--shadow);padding:16px}
 .card h3{margin:0 0 8px}
-.project .project-head{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:6px}
+.card p{margin:0 0 12px}
+.card p:last-child{margin-bottom:0}
+.card ul{margin:0;padding-left:18px}
+.card li+li{margin-top:8px}
+.project .project-head{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px}
 .tag{font-size:.8rem;color:#001b2e;background:linear-gradient(135deg, var(--brand), var(--brand-2));padding:4px 8px;border-radius:999px;font-weight:800}
 .note.ext{margin-top:12px;color:var(--muted)}
 


### PR DESCRIPTION
## Summary
- set a comfortable global body line-height and add explicit heading line-height values
- tighten hero copy margins and normalize list/card spacing to preserve the 4px/8px rhythm

## Testing
- Manual viewport review at 320px and 1440px

------
https://chatgpt.com/codex/tasks/task_e_68cbc1a70afc83238b2fe8b0cff6dac5