### PR TITLE
Add scroll-based active nav highlighting

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -29,6 +29,8 @@ body{
 .nav-toggle{display:none;background:transparent;border:1px solid var(--line);color:var(--ink);padding:8px 10px;border-radius:10px}
 .nav-links{display:flex;gap:12px;flex-wrap:wrap}
 .nav-link{color:var(--ink);text-decoration:none;padding:8px 12px;border-radius:10px;border:1px solid transparent}
+.nav-link[aria-current="true"]{font-weight:700;border-color:var(--brand);background:rgba(54,163,255,.18);box-shadow:inset 0 -3px 0 var(--brand-2)}
+.nav-link[aria-current="true"]:hover,.nav-link[aria-current="true"]:focus{background:rgba(54,163,255,.25);box-shadow:inset 0 -3px 0 var(--brand-2)}
 .nav-link:hover,.nav-link:focus{background:rgba(108,194,255,.08);border-color:var(--line);outline:none;box-shadow:0 0 0 4px var(--ring)}
 .nav-link.external{border-color:var(--line)}
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -32,6 +32,78 @@
     });
   }
 
+  (() => {
+    const navLinks = Array.from(document.querySelectorAll('.nav-link[href^="#"]'));
+    if (!navLinks.length) return;
+
+    const header = document.querySelector('.header');
+    const headerOffset = header ? header.offsetHeight + 12 : 70;
+    const linkById = new Map(navLinks.map(link => [link.getAttribute('href').slice(1), link]));
+    const sections = Array.from(document.querySelectorAll('main section[id]')).filter(section => linkById.has(section.id));
+    let activeId = null;
+
+    const setActive = id => {
+      const nextId = linkById.has(id) ? id : null;
+      if (activeId === nextId) return;
+      activeId = nextId;
+      navLinks.forEach(link => link.removeAttribute('aria-current'));
+      if (nextId) linkById.get(nextId)?.setAttribute('aria-current', 'true');
+    };
+
+    const clearIfAboveFirst = () => {
+      if (!sections.length) return false;
+      if (window.scrollY + headerOffset < sections[0].offsetTop) {
+        setActive(null);
+        return true;
+      }
+      return false;
+    };
+
+    const fallbackSelection = () => {
+      if (!sections.length || clearIfAboveFirst()) return;
+      const reference = window.scrollY + headerOffset;
+      let currentId = sections[0].id;
+      sections.forEach(section => {
+        if (reference >= section.offsetTop) currentId = section.id;
+      });
+      setActive(currentId);
+    };
+
+    navLinks.forEach(link => {
+      link.addEventListener('click', () => setActive(link.getAttribute('href').slice(1)));
+    });
+
+    if ('IntersectionObserver' in window && sections.length) {
+      const visibleSections = new Map();
+      const observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            visibleSections.set(entry.target.id, entry.intersectionRatio);
+          } else {
+            visibleSections.delete(entry.target.id);
+          }
+        });
+        if (visibleSections.size) {
+          const [id] = Array.from(visibleSections.entries()).sort((a, b) => b[1] - a[1])[0];
+          setActive(id);
+        } else {
+          fallbackSelection();
+        }
+      }, { rootMargin: `-${headerOffset}px 0px -45% 0px`, threshold: [0.1, 0.25, 0.5, 0.75] });
+      sections.forEach(section => observer.observe(section));
+      window.addEventListener('scroll', () => {
+        if (!visibleSections.size) fallbackSelection();
+      }, { passive: true });
+      fallbackSelection();
+    } else {
+      window.addEventListener('scroll', fallbackSelection, { passive: true });
+      fallbackSelection();
+    }
+
+    const hashId = location.hash.slice(1);
+    if (linkById.has(hashId)) setActive(hashId);
+  })();
+
   document.querySelectorAll('[data-print]').forEach(btn=>btn.addEventListener('click',()=>window.print()));
   document.querySelectorAll('[data-share]').forEach(btn=>btn.addEventListener('click',async()=>{
     const data = { title: document.title, url: location.href };


### PR DESCRIPTION
## Summary
- track sections within the main content and update nav aria-current based on scroll position
- provide an IntersectionObserver implementation with a scroll-based fallback for older browsers
- style the active navigation link to remain visually distinct from hover and focus states

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cbc1a52ea8832399ac63aa0ad36f8e