### PR TITLE
Rebuild portfolio as multi-page experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,26 @@
-# Putu Astika — Portfolio (Pro Dark/Blue)
+# Putu Astika — Portfolio (Multi-page Dark/Blue)
 
-A fast, professional portfolio with a dark navy + electric blue aesthetic.
+A world-class, multi-page portfolio with a dark navy + electric blue aesthetic.
 
 ## Features
-- Sticky, translucent navbar with mobile menu
-- Clean hero section (100vh) with strong headline
-- Projects grid (cards)
-- Certificates section (FCC: RWD + Front End Libraries)
-- Contact & quick resume preview
-- Accessible focus states, reduced motion handling
-- Print & Web Share helpers
+- Sticky, translucent navbar with mobile focus trap and active-page highlighting
+- Immersive hero with availability meta panel
+- Dedicated pages for Work, Skills (with resume snapshot), About, and Contact
+- Project case studies with imagery, feature lists, and outbound links
+- Certificates and resume actions (PDF, print, share)
+- Accessible focus states, reduced motion handling, and skip link
 - Lightweight: vanilla HTML/CSS/JS (no build step)
 
+## Pages
+- `index.html` — Hero, focus areas, highlighted projects, contact CTA
+- `work.html` — Deep dives into PromptCraft, Ops Playbook, and Mini-Tools
+- `skills.html` — Capabilities grid, certifications, resume snapshot
+- `about.html` — Working style, background, and tooling overview
+- `contact.html` — Preferred channels, availability, and logistics
+
 ## Customize
-- **Links:** Update project URLs, email/WhatsApp, and resume link in `index.html`.
-- **Brand:** Replace `assets/logo.svg` as needed. Colors are in CSS variables.
+- **Links:** Update project URLs, email/WhatsApp, and resume link in the respective pages.
+- **Brand:** Replace `assets/profile.png` and `assets/logo.svg` as needed. Colors are in CSS variables.
 - **OG image:** Replace `assets/og-image.png` (1200×630).
 
 ## Deploy to GitHub Pages

--- a/about.html
+++ b/about.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>About — Putu Astika</title>
+  <meta name="description" content="Ops-first generalist with a content background who builds small, durable web tools." />
+  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="assets/profile.png" type="image/png" />
+  <meta property="og:title" content="About — Putu Astika" />
+  <meta property="og:description" content="Ops-first generalist with a content background who builds small, durable web tools." />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="assets/og-image.png" />
+  <meta property="og:url" content="https://astika.is-a.dev/about.html" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+</head>
+<body data-page="about">
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <div id="top" aria-hidden="true"></div>
+
+  <header class="site-header" data-nav>
+    <nav class="nav" aria-label="Primary">
+      <a class="nav__brand" href="index.html" aria-label="Homepage" title="Putu Astika">
+        <img src="assets/profile.png" alt="PA logo" width="32" height="32" />
+        <span class="nav__brand-text">Putu Astika</span>
+      </a>
+      <button class="nav__toggle" type="button" aria-controls="nav-menu" aria-expanded="false" aria-label="Toggle navigation" data-nav-toggle>
+        <span aria-hidden="true">☰</span>
+      </button>
+      <div class="nav__menu" id="nav-menu" data-nav-menu>
+        <a class="nav__link" href="index.html" data-page-link="home">Home</a>
+        <a class="nav__link" href="work.html" data-page-link="work">Work</a>
+        <a class="nav__link" href="skills.html" data-page-link="skills resume">Skills</a>
+        <a class="nav__link" href="about.html" data-page-link="about">About</a>
+        <a class="nav__link" href="contact.html" data-page-link="contact">Contact</a>
+        <a class="nav__link nav__link--external" href="https://astika327-dev.github.io/bali-webdeveloper/index.html" target="_blank" rel="noopener">Bali WebDeveloper ↗</a>
+        <a class="nav__cta" href="skills.html#resume" data-page-link="skills resume">Resume</a>
+      </div>
+    </nav>
+  </header>
+
+  <main id="main-content" tabindex="-1">
+    <section class="page-hero">
+      <p class="eyebrow">About</p>
+      <h1>Ops‑first generalist with a content background who builds small, durable web tools.</h1>
+      <p>I optimize workflows, document knowledge, and ship pragmatic features—preferably with simple tech that’s easy to maintain.</p>
+    </section>
+
+    <section class="section" aria-labelledby="approach-heading">
+      <div class="section__header">
+        <h2 id="approach-heading">How I work</h2>
+        <p class="section__lede">Reliable delivery, practical scope, and documentation that keeps teams aligned.</p>
+      </div>
+      <div class="pill-grid">
+        <div class="pill">Ships fast with clear acceptance criteria</div>
+        <div class="pill">Prefers simplicity over ceremony</div>
+        <div class="pill">Writes docs and checklists people actually use</div>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="background-heading">
+      <div class="section__header">
+        <h2 id="background-heading">What clients count on</h2>
+        <p class="section__lede">The mix of production skills and operations habits that keeps projects moving without drama.</p>
+      </div>
+      <div class="card-grid card-grid--two">
+        <article class="card">
+          <h3>Builder mindset</h3>
+          <ul>
+            <li>Semantic HTML layouts that stay accessible</li>
+            <li>Modern CSS architecture with Flex/Grid and variables</li>
+            <li>Browser-friendly JS (DOM, fetch, modules)</li>
+            <li>Version control via Git &amp; GitHub Pages</li>
+          </ul>
+        </article>
+        <article class="card">
+          <h3>Operator discipline</h3>
+          <ul>
+            <li>Prompt design systems with evaluation loops</li>
+            <li>Grounding, fact-checking, and review checkpoints</li>
+            <li>Workflow automation ideas for repeatable tasks</li>
+            <li>Clear communication in Notion, Google Suite, and Figma</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="tools-heading">
+      <div class="section__header">
+        <h2 id="tools-heading">Tools I keep close</h2>
+        <p class="section__lede">Chrome DevTools, VS Code, and the content systems that make collaboration frictionless.</p>
+      </div>
+      <ul class="inline-list">
+        <li>Figma</li>
+        <li>Canva</li>
+        <li>Notion</li>
+        <li>Google Suite</li>
+        <li>Chrome DevTools</li>
+        <li>VS Code</li>
+      </ul>
+    </section>
+
+    <section class="cta">
+      <div class="cta__content">
+        <h2>Need a steady operator?</h2>
+        <p>Short message, clear ask. Open for freelance and collaboration.</p>
+        <div class="cta__actions">
+          <a class="btn btn--ghost" href="mailto:astika327@gmail.com">Email</a>
+          <a class="btn btn--ghost" href="https://wa.me/6282146178461" target="_blank" rel="noopener">WhatsApp</a>
+          <a class="btn btn--ghost" href="https://github.com/astika327-dev" target="_blank" rel="noopener">GitHub</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>© <span id="year"></span> Putu Astika — Built with hand‑crafted HTML, CSS, and JS.</p>
+  </footer>
+
+  <script src="assets/js/script.js"></script>
+</body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,124 +1,737 @@
-:root{
-  --bg: #0b1220;
-  --bg-2: #0e1528;
-  --ink: #e9eefc;
-  --muted: #a8b2d1;
-  --line: rgba(255,255,255,.08);
-  --brand: #36a3ff;
-  --brand-2: #6cc2ff;
-  --card: #111a2e;
-  --card-2: #0f1830;
-  --ring: rgba(255,255,255,.7);
-  --shadow: 0 10px 30px rgba(0,0,0,.35);
-}
-*{box-sizing:border-box}
-html,body{height:100%}
-html{scroll-behavior:smooth}
-body{
-  margin:0;
-  color:var(--ink);
-  background: radial-gradient(1200px 600px at 50% -20%, #102040 0%, transparent 60%), var(--bg);
-  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+:root {
+  color-scheme: dark;
+  --bg: #050914;
+  --bg-alt: #0b1224;
+  --surface: rgba(11, 18, 36, 0.78);
+  --surface-strong: rgba(15, 24, 48, 0.92);
+  --surface-outline: rgba(255, 255, 255, 0.08);
+  --ink: #f5f8ff;
+  --ink-subtle: #c3c9e5;
+  --accent: #5fd0ff;
+  --accent-strong: #2a90ff;
+  --shadow: 0 20px 45px rgba(5, 9, 20, 0.45);
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --max-width: 1160px;
+  --transition: 0.24s cubic-bezier(0.37, 0, 0.63, 1);
 }
 
-.skip-link{
-  position:absolute;
-  top:0;
-  left:0;
-  transform:translateY(-120%);
-  padding:12px 18px;
-  background:#0b1220;
-  color:#ffffff;
-  font-weight:700;
-  text-decoration:none;
-  border-bottom-right-radius:12px;
-  box-shadow:0 8px 18px rgba(0,0,0,.35);
-  transition:transform .2s ease, opacity .2s ease;
-  z-index:100;
-  opacity:0;
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  color: var(--ink);
+  background: radial-gradient(circle at top, rgba(42, 144, 255, 0.18) 0%, transparent 60%),
+              radial-gradient(circle at 20% 80%, rgba(95, 208, 255, 0.12) 0%, transparent 55%),
+              linear-gradient(160deg, var(--bg), var(--bg-alt));
+  line-height: 1.6;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(600px 400px at 75% 20%, rgba(95, 208, 255, 0.08), transparent 70%),
+              radial-gradient(480px 380px at 10% 90%, rgba(42, 144, 255, 0.08), transparent 65%);
+  pointer-events: none;
+  z-index: -1;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent);
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius-md);
+  display: block;
+}
+
+main {
+  display: block;
+}
+
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(-120%);
+  padding: 12px 18px;
+  background: var(--surface-strong);
+  color: var(--ink);
+  font-weight: 700;
+  text-decoration: none;
+  border-bottom-right-radius: var(--radius-md);
+  box-shadow: var(--shadow);
+  transition: transform var(--transition), opacity var(--transition);
+  opacity: 0;
+  z-index: 1000;
 }
 
 .skip-link:focus,
-.skip-link:focus-visible,
-.skip-link:active{
-  transform:translateY(0);
-  opacity:1;
-  outline:2px solid var(--brand);
-  outline-offset:4px;
+.skip-link:active {
+  transform: translateY(0);
+  opacity: 1;
+  outline: 3px solid var(--accent);
+  outline-offset: 4px;
 }
 
-/* Header / Navbar */
-.header{position:sticky;top:0;z-index:50;background:linear-gradient(180deg, rgba(11,18,32,.9), rgba(11,18,32,.6));backdrop-filter:saturate(1.2) blur(6px);border-bottom:1px solid var(--line)}
-.nav{max-width:1140px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 16px}
-.brand{display:inline-flex;align-items:center;gap:10px;color:var(--ink);text-decoration:none;font-weight:800}
-.brand img{display:block}
-.nav-toggle{display:none;background:transparent;border:1px solid var(--line);color:var(--ink);padding:8px 10px;border-radius:10px}
-.nav-toggle:focus-visible{outline:none;border-color:#fff;box-shadow:0 0 0 4px var(--ring)}
-.nav-links{display:flex;gap:12px;flex-wrap:wrap}
-.nav-link{color:var(--ink);text-decoration:none;padding:8px 12px;border-radius:10px;border:1px solid transparent}
-.nav-link[aria-current="true"]{font-weight:700;border-color:var(--brand);background:rgba(54,163,255,.18);box-shadow:inset 0 -3px 0 var(--brand-2)}
-.nav-link[aria-current="true"]:hover,.nav-link[aria-current="true"]:focus{background:rgba(54,163,255,.25);box-shadow:inset 0 -3px 0 var(--brand-2)}
-.nav-link:hover,.nav-link:focus{background:rgba(108,194,255,.08);border-color:var(--line);outline:none;box-shadow:0 0 0 4px var(--ring)}
-.nav-link.external{border-color:var(--line)}
-
-/* Sections / layout */
-.section{max-width:1140px;margin:0 auto;padding: clamp(20px, 5vw, 48px) 16px;border-top:1px solid var(--line)}
-.section h2{font-size:clamp(1.2rem,2.6vw,1.8rem);margin:0 0 14px}
-.bullets{margin:10px 0 0 0;padding-left:18px;color:var(--muted)}
-
-/* Hero */
-.hero{min-height:100vh;max-width:1140px;margin:0 auto;padding: clamp(40px, 8vw, 120px) 16px;display:grid;align-content:center;gap:16px}
-.hero-title{font-size: clamp(2rem, 5vw, 3.2rem);line-height:1.15;margin:0}
-.hero-sub{color:var(--muted);max-width:820px}
-.hero-actions{display:flex;gap:10px;flex-wrap:wrap}
-.hero-meta{color:var(--muted);opacity:.9;margin-top:8px}
-
-/* Cards & grids */
-.cards{display:grid;gap:14px}
-.cards.two{grid-template-columns:repeat(2, minmax(0,1fr))}
-.cards.three{grid-template-columns:repeat(3, minmax(0,1fr))}
-.card{background: linear-gradient(180deg, var(--card), var(--card-2));border:1px solid var(--line);border-radius:16px;box-shadow:var(--shadow);padding:16px}
-.card h3{margin:0 0 8px}
-.project .project-head{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:6px}
-.tag{font-size:.8rem;color:#001b2e;background:linear-gradient(135deg, var(--brand), var(--brand-2));padding:4px 8px;border-radius:999px;font-weight:800}
-.note.ext{margin-top:12px;color:var(--muted)}
-
-/* Buttons */
-.btn{display:inline-block;text-decoration:none;font-weight:700;border-radius:12px;padding:10px 14px}
-.btn.primary{background:linear-gradient(135deg, var(--brand), var(--brand-2));color:#001b2e}
-.btn.ghost{background:transparent;color:var(--ink);border:2px solid var(--brand)}
-.btn:hover{filter:brightness(1.08)}
-.btn:focus-visible,
-a.btn:focus-visible,
-button.btn:focus-visible{outline:none;box-shadow:0 0 0 4px var(--ring)}
-
-/* Resume mini */
-.resume-mini ul{margin:8px 0 0 0;padding-left:18px;color:var(--muted)}
-.small{font-size:.9rem}
-.muted{color:var(--muted)}
-
-/* Footer */
-.footer{border-top:1px solid var(--line);text-align:center;color:var(--muted);padding:18px 16px}
-
-/* Responsive */
-@media (max-width: 960px){
-  .cards.three{grid-template-columns:repeat(2, minmax(0,1fr))}
-}
-@media (max-width: 680px){
-  .cards.two, .cards.three{grid-template-columns:1fr}
-  .nav-toggle{display:inline-block}
-  .nav-links{display:none;flex-direction:column;align-items:flex-start;background:rgba(15,24,48,.95);border:1px solid var(--line);border-radius:12px;padding:8px;position:absolute;top:56px;right:16px;min-width:220px}
-  .nav-links.open{display:flex}
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 900;
+  backdrop-filter: saturate(1.25) blur(18px);
+  background: rgba(5, 9, 20, 0.7);
+  border-bottom: 1px solid var(--surface-outline);
 }
 
-/* Print */
-@media print{
-  .header, .hero-actions, .actions .btn[data-share]{display:none}
-  body{background:#fff;color:#000}
+.nav {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 18px;
 }
 
-/* Reduced motion */
-@media (prefers-reduced-motion: reduce){
-  html{scroll-behavior:auto}
-  *{transition:none !important}
+.nav__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.nav__brand-text {
+  letter-spacing: 0.04em;
+}
+
+.nav__toggle {
+  display: none;
+  background: transparent;
+  border: 1px solid var(--surface-outline);
+  color: var(--ink);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.nav__toggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(95, 208, 255, 0.45);
+}
+
+.nav__menu {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.nav__link,
+.nav__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+  font-weight: 600;
+  padding: 9px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  transition: background var(--transition), border-color var(--transition), color var(--transition);
+}
+
+.nav__link:hover,
+.nav__link:focus-visible,
+.nav__cta:hover,
+.nav__cta:focus-visible {
+  outline: none;
+  color: var(--ink);
+  background: rgba(95, 208, 255, 0.12);
+  border-color: rgba(95, 208, 255, 0.3);
+}
+
+.nav__link[aria-current="page"] {
+  border-color: rgba(95, 208, 255, 0.4);
+  background: linear-gradient(140deg, rgba(95, 208, 255, 0.16), rgba(42, 144, 255, 0.16));
+  box-shadow: inset 0 -2px 0 rgba(95, 208, 255, 0.35);
+}
+
+.nav__link--external::after {
+  content: "↗";
+  margin-left: 6px;
+  font-size: 0.85em;
+}
+
+.nav__cta {
+  border: 1px solid rgba(95, 208, 255, 0.4);
+  background: linear-gradient(130deg, rgba(95, 208, 255, 0.18), rgba(42, 144, 255, 0.22));
+  color: #011a2f;
+  font-weight: 700;
+}
+
+.hero,
+.page-hero {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: clamp(3.5rem, 9vw, 6rem) clamp(1.2rem, 4vw, 2.2rem);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  gap: clamp(2rem, 6vw, 4rem);
+  align-items: center;
+}
+
+.hero__text {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero__title {
+  font-size: clamp(2.6rem, 6vw, 4rem);
+  margin: 0;
+  line-height: 1.05;
+}
+
+.hero__lead {
+  margin: 0;
+  color: var(--ink-subtle);
+  font-size: clamp(1.05rem, 2.4vw, 1.25rem);
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.hero__meta {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 1.5rem;
+  margin: 0;
+  color: var(--ink-subtle);
+}
+
+.hero__meta dt {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-bottom: 0.2rem;
+}
+
+.hero__meta dd {
+  margin: 0;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.hero__panel {
+  display: flex;
+  align-items: stretch;
+}
+
+.panel-card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.6rem, 3vw, 2rem);
+  border: 1px solid var(--surface-outline);
+  box-shadow: var(--shadow);
+}
+
+.panel-card h2 {
+  margin: 0 0 0.8rem;
+  font-size: 1.4rem;
+}
+
+.panel-card p {
+  margin: 0 0 1rem;
+  color: var(--ink-subtle);
+}
+
+.panel-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.4rem;
+  color: var(--ink-subtle);
+}
+
+.eyebrow {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  color: rgba(95, 208, 255, 0.76);
+  margin: 0 0 1rem;
+}
+
+.page-hero h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2.1rem, 5vw, 3.3rem);
+}
+
+.page-hero p {
+  margin: 0;
+  color: var(--ink-subtle);
+  max-width: 60ch;
+}
+
+.section {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: clamp(3rem, 8vw, 5rem) clamp(1.2rem, 4vw, 2.2rem);
+  display: grid;
+  gap: clamp(1.8rem, 5vw, 2.6rem);
+}
+
+.section--highlight {
+  background: rgba(5, 9, 20, 0.55);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(95, 208, 255, 0.16);
+  box-shadow: var(--shadow);
+}
+
+.section__header {
+  display: grid;
+  gap: 0.6rem;
+  max-width: 60ch;
+}
+
+.section__header h2 {
+  margin: 0;
+  font-size: clamp(1.5rem, 3.6vw, 2.2rem);
+}
+
+.section__lede {
+  margin: 0;
+  color: var(--ink-subtle);
+}
+
+.section__footer {
+  margin-top: -0.8rem;
+}
+
+.link-arrow {
+  font-weight: 600;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.link-arrow::after {
+  content: "↗";
+  transition: transform var(--transition);
+}
+
+.link-arrow:hover::after,
+.link-arrow:focus-visible::after {
+  transform: translateX(4px);
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.4rem;
+}
+
+.card-grid--two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.card-grid--three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--surface-outline);
+  padding: clamp(1.4rem, 3vw, 1.9rem);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 0.8rem;
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--ink-subtle);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.card--focus {
+  background: linear-gradient(160deg, rgba(95, 208, 255, 0.12), rgba(11, 18, 36, 0.7));
+}
+
+.card--cert p,
+.card--contact p {
+  color: var(--ink-subtle);
+  margin: 0;
+}
+
+.card--contact .btn {
+  justify-self: flex-start;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  font-weight: 700;
+  text-decoration: none;
+  padding: 10px 18px;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition: transform var(--transition), filter var(--transition), border-color var(--transition);
+}
+
+.btn--primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #011a2f;
+  box-shadow: 0 12px 30px rgba(42, 144, 255, 0.35);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--ink);
+  border-color: rgba(95, 208, 255, 0.45);
+}
+
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-1px);
+  filter: brightness(1.05);
+  outline: none;
+}
+
+.project-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.project-card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--surface-outline);
+  display: grid;
+  grid-template-rows: auto 1fr;
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
+
+.project-card__media {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  border-radius: 0;
+}
+
+.project-card__body {
+  padding: 1.6rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.project-card__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.project-card__top h3 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.project-card__tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #011a2f;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+}
+
+.project-card__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.project-section {
+  position: relative;
+}
+
+.project-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.05fr);
+  gap: clamp(1.6rem, 5vw, 2.8rem);
+  align-items: center;
+}
+
+.project-layout--flip {
+  direction: rtl;
+}
+
+.project-layout--flip > * {
+  direction: ltr;
+}
+
+.project-layout__media img {
+  width: 100%;
+  height: auto;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+}
+
+.project-layout__content {
+  display: grid;
+  gap: 1.2rem;
+}
+
+.feature-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--ink-subtle);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.pill-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.pill {
+  border-radius: 999px;
+  padding: 0.65rem 1.2rem;
+  border: 1px solid rgba(95, 208, 255, 0.3);
+  background: rgba(5, 9, 20, 0.4);
+  font-weight: 500;
+}
+
+.inline-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.9rem;
+  color: var(--ink-subtle);
+}
+
+.inline-list li {
+  padding: 0.5rem 0.9rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(95, 208, 255, 0.26);
+  background: rgba(5, 9, 20, 0.4);
+}
+
+.resume-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.4rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.resume-panel__body {
+  flex: 1 1 260px;
+}
+
+.resume-panel__body h3 {
+  margin: 0 0 0.6rem;
+}
+
+.resume-panel__body ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--ink-subtle);
+  display: grid;
+  gap: 0.45rem;
+}
+
+.resume-panel__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.cta {
+  max-width: var(--max-width);
+  margin: 0 auto clamp(3rem, 8vw, 5rem);
+  padding: 0 clamp(1.2rem, 4vw, 2.2rem);
+}
+
+.cta__content {
+  background: linear-gradient(150deg, rgba(95, 208, 255, 0.2), rgba(11, 18, 36, 0.8));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(95, 208, 255, 0.26);
+  padding: clamp(2.4rem, 6vw, 3.6rem);
+  display: grid;
+  gap: 1.2rem;
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+
+.cta__content h2 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+}
+
+.cta__content p {
+  margin: 0;
+  color: var(--ink-subtle);
+}
+
+.cta__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.site-footer {
+  border-top: 1px solid var(--surface-outline);
+  text-align: center;
+  color: var(--ink-subtle);
+  padding: 1.5rem 1rem 2rem;
+}
+
+.logistics-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.2rem;
+}
+
+.logistics-card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--surface-outline);
+  padding: 1.4rem;
+  text-align: center;
+  box-shadow: var(--shadow);
+}
+
+.logistics-card h3 {
+  margin: 0 0 0.4rem;
+}
+
+@media (max-width: 1024px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .project-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .project-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .project-layout--flip {
+    direction: ltr;
+  }
+
+  .hero__panel {
+    order: -1;
+  }
+}
+
+@media (max-width: 820px) {
+  .nav__toggle {
+    display: inline-flex;
+  }
+
+  .nav__menu {
+    position: absolute;
+    right: 18px;
+    top: 70px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.6rem;
+    padding: 1rem;
+    min-width: 240px;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--surface-outline);
+    background: var(--surface-strong);
+    box-shadow: var(--shadow);
+    display: none;
+  }
+
+  .nav__menu.open {
+    display: flex;
+  }
+
+  .hero__meta {
+    grid-auto-flow: row;
+    gap: 0.8rem;
+  }
+
+  .project-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card-grid--two,
+  .card-grid--three,
+  .logistics-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *, *::before, *::after {
+    transition: none !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}
+
+@media print {
+  body {
+    background: #fff;
+    color: #000;
+  }
+
+  .site-header,
+  .cta,
+  .nav__toggle,
+  .nav__menu,
+  .nav__cta,
+  [data-share] {
+    display: none !important;
+  }
 }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -2,49 +2,63 @@
   const year = document.getElementById('year');
   if (year) year.textContent = new Date().getFullYear();
 
-  const toggle = document.querySelector('.nav-toggle');
-  const links  = document.getElementById('nav-links');
-  if (toggle && links){
+  const bodyPage = document.body.dataset.page;
+  if (bodyPage) {
+    document.querySelectorAll('[data-page-link]').forEach(link => {
+      const pages = (link.dataset.pageLink || '').split(/\s+/).filter(Boolean);
+      if (pages.includes(bodyPage)) {
+        link.setAttribute('aria-current', 'page');
+      } else {
+        link.removeAttribute('aria-current');
+      }
+    });
+  }
+
+  const toggle = document.querySelector('[data-nav-toggle]');
+  const menu = document.querySelector('[data-nav-menu]');
+  if (toggle && menu) {
     let focusableMenuItems = [];
+
+    const focusableSelectors = 'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
     const collectFocusable = () => {
-      const selectors = 'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
-      const elements = Array.from(links.querySelectorAll(selectors));
-      if (!elements.includes(toggle)) elements.push(toggle);
-      focusableMenuItems = elements.filter(el => !el.hasAttribute('disabled'));
+      const items = Array.from(menu.querySelectorAll(focusableSelectors));
+      if (!items.includes(toggle)) items.push(toggle);
+      focusableMenuItems = items.filter(el => !el.hasAttribute('disabled'));
     };
 
     const openMenu = () => {
-      links.classList.add('open');
+      menu.classList.add('open');
       toggle.setAttribute('aria-expanded', 'true');
-      links.setAttribute('aria-modal', 'true');
+      menu.setAttribute('data-open', 'true');
       collectFocusable();
+      if (focusableMenuItems.length) focusableMenuItems[0].focus();
     };
 
     const closeMenu = () => {
-      if (!links.classList.contains('open')) return;
-      links.classList.remove('open');
+      if (!menu.classList.contains('open')) return;
+      menu.classList.remove('open');
       toggle.setAttribute('aria-expanded', 'false');
-      links.removeAttribute('aria-modal');
+      menu.removeAttribute('data-open');
       focusableMenuItems = [];
       toggle.focus();
     };
 
     toggle.addEventListener('click', () => {
-      if (links.classList.contains('open')) {
+      if (menu.classList.contains('open')) {
         closeMenu();
       } else {
         openMenu();
       }
     });
 
-    links.querySelectorAll('a').forEach(anchor => {
+    menu.querySelectorAll('a').forEach(anchor => {
       anchor.addEventListener('click', () => {
-        if (links.classList.contains('open')) closeMenu();
+        if (menu.classList.contains('open')) closeMenu();
       });
     });
 
     document.addEventListener('keydown', event => {
-      if (!links.classList.contains('open')) return;
+      if (!menu.classList.contains('open')) return;
 
       if (event.key === 'Escape') {
         event.preventDefault();
@@ -68,88 +82,29 @@
     });
 
     document.addEventListener('click', event => {
-      if (!links.classList.contains('open')) return;
-      if (event.target instanceof Node && (links.contains(event.target) || toggle.contains(event.target))) return;
+      if (!menu.classList.contains('open')) return;
+      if (event.target instanceof Node && (menu.contains(event.target) || toggle.contains(event.target))) return;
       closeMenu();
     });
   }
 
-  (() => {
-    const navLinks = Array.from(document.querySelectorAll('.nav-link[href^="#"]'));
-    if (!navLinks.length) return;
+  document.querySelectorAll('[data-print]').forEach(btn => {
+    btn.addEventListener('click', () => window.print());
+  });
 
-    const header = document.querySelector('.header');
-    const headerOffset = header ? header.offsetHeight + 12 : 70;
-    const linkById = new Map(navLinks.map(link => [link.getAttribute('href').slice(1), link]));
-    const sections = Array.from(document.querySelectorAll('main section[id]')).filter(section => linkById.has(section.id));
-    let activeId = null;
-
-    const setActive = id => {
-      const nextId = linkById.has(id) ? id : null;
-      if (activeId === nextId) return;
-      activeId = nextId;
-      navLinks.forEach(link => link.removeAttribute('aria-current'));
-      if (nextId) linkById.get(nextId)?.setAttribute('aria-current', 'true');
-    };
-
-    const clearIfAboveFirst = () => {
-      if (!sections.length) return false;
-      if (window.scrollY + headerOffset < sections[0].offsetTop) {
-        setActive(null);
-        return true;
-      }
-      return false;
-    };
-
-    const fallbackSelection = () => {
-      if (!sections.length || clearIfAboveFirst()) return;
-      const reference = window.scrollY + headerOffset;
-      let currentId = sections[0].id;
-      sections.forEach(section => {
-        if (reference >= section.offsetTop) currentId = section.id;
-      });
-      setActive(currentId);
-    };
-
-    navLinks.forEach(link => {
-      link.addEventListener('click', () => setActive(link.getAttribute('href').slice(1)));
-    });
-
-    if ('IntersectionObserver' in window && sections.length) {
-      const visibleSections = new Map();
-      const observer = new IntersectionObserver(entries => {
-        entries.forEach(entry => {
-          if (entry.isIntersecting) {
-            visibleSections.set(entry.target.id, entry.intersectionRatio);
-          } else {
-            visibleSections.delete(entry.target.id);
-          }
-        });
-        if (visibleSections.size) {
-          const [id] = Array.from(visibleSections.entries()).sort((a, b) => b[1] - a[1])[0];
-          setActive(id);
-        } else {
-          fallbackSelection();
+  document.querySelectorAll('[data-share]').forEach(btn => {
+    btn.addEventListener('click', async () => {
+      const data = { title: document.title, url: location.href };
+      try {
+        if (navigator.share) {
+          await navigator.share(data);
+        } else if (navigator.clipboard && navigator.clipboard.writeText) {
+          await navigator.clipboard.writeText(location.href);
+          alert('Link copied to clipboard');
         }
-      }, { rootMargin: `-${headerOffset}px 0px -45% 0px`, threshold: [0.1, 0.25, 0.5, 0.75] });
-      sections.forEach(section => observer.observe(section));
-      window.addEventListener('scroll', () => {
-        if (!visibleSections.size) fallbackSelection();
-      }, { passive: true });
-      fallbackSelection();
-    } else {
-      window.addEventListener('scroll', fallbackSelection, { passive: true });
-      fallbackSelection();
-    }
-
-    const hashId = location.hash.slice(1);
-    if (linkById.has(hashId)) setActive(hashId);
-  })();
-
-  document.querySelectorAll('[data-print]').forEach(btn=>btn.addEventListener('click',()=>window.print()));
-  document.querySelectorAll('[data-share]').forEach(btn=>btn.addEventListener('click',async()=>{
-    const data = { title: document.title, url: location.href };
-    try{ if(navigator.share){ await navigator.share(data); } else { await navigator.clipboard.writeText(location.href); alert('Link copied to clipboard'); } }
-    catch(e){ console.warn(e); }
-  }));
+      } catch (error) {
+        console.warn(error);
+      }
+    });
+  });
 })();

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Contact — Putu Astika</title>
+  <meta name="description" content="Contact Putu Astika for freelance and collaboration opportunities." />
+  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="assets/profile.png" type="image/png" />
+  <meta property="og:title" content="Contact — Putu Astika" />
+  <meta property="og:description" content="Contact Putu Astika for freelance and collaboration opportunities." />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="assets/og-image.png" />
+  <meta property="og:url" content="https://astika.is-a.dev/contact.html" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+</head>
+<body data-page="contact">
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <div id="top" aria-hidden="true"></div>
+
+  <header class="site-header" data-nav>
+    <nav class="nav" aria-label="Primary">
+      <a class="nav__brand" href="index.html" aria-label="Homepage" title="Putu Astika">
+        <img src="assets/profile.png" alt="PA logo" width="32" height="32" />
+        <span class="nav__brand-text">Putu Astika</span>
+      </a>
+      <button class="nav__toggle" type="button" aria-controls="nav-menu" aria-expanded="false" aria-label="Toggle navigation" data-nav-toggle>
+        <span aria-hidden="true">☰</span>
+      </button>
+      <div class="nav__menu" id="nav-menu" data-nav-menu>
+        <a class="nav__link" href="index.html" data-page-link="home">Home</a>
+        <a class="nav__link" href="work.html" data-page-link="work">Work</a>
+        <a class="nav__link" href="skills.html" data-page-link="skills resume">Skills</a>
+        <a class="nav__link" href="about.html" data-page-link="about">About</a>
+        <a class="nav__link" href="contact.html" data-page-link="contact">Contact</a>
+        <a class="nav__link nav__link--external" href="https://astika327-dev.github.io/bali-webdeveloper/index.html" target="_blank" rel="noopener">Bali WebDeveloper ↗</a>
+        <a class="nav__cta" href="skills.html#resume" data-page-link="skills resume">Resume</a>
+      </div>
+    </nav>
+  </header>
+
+  <main id="main-content" tabindex="-1">
+    <section class="page-hero">
+      <p class="eyebrow">Contact</p>
+      <h1>Short message, clear ask. Open for freelance and collaboration.</h1>
+      <p>Outline the problem, the desired outcome, and where the work will live. I’ll reply within one business day.</p>
+    </section>
+
+    <section class="section" aria-labelledby="channels-heading">
+      <div class="section__header">
+        <h2 id="channels-heading">Preferred channels</h2>
+        <p class="section__lede">Pick the lane that suits your workflow. I keep response windows tight.</p>
+      </div>
+      <div class="card-grid card-grid--three">
+        <article class="card card--contact">
+          <h3>Email</h3>
+          <p>Detailed briefs, attachments, and timelines.</p>
+          <a class="btn btn--ghost" href="mailto:astika327@gmail.com">astika327@gmail.com</a>
+        </article>
+        <article class="card card--contact">
+          <h3>WhatsApp</h3>
+          <p>Fast check-ins or voice notes when async isn’t enough.</p>
+          <a class="btn btn--ghost" href="https://wa.me/6282146178461" target="_blank" rel="noopener">+62 821 4617 8461</a>
+        </article>
+        <article class="card card--contact">
+          <h3>GitHub</h3>
+          <p>See build history, source, and documentation habits.</p>
+          <a class="btn btn--ghost" href="https://github.com/astika327-dev" target="_blank" rel="noopener">github.com/astika327-dev</a>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="logistics-heading">
+      <div class="section__header">
+        <h2 id="logistics-heading">Logistics</h2>
+        <p class="section__lede">Transparent about availability, timezone, and how to kick things off.</p>
+      </div>
+      <div class="logistics-grid">
+        <div class="logistics-card">
+          <h3>Availability</h3>
+          <p>Available for work</p>
+        </div>
+        <div class="logistics-card">
+          <h3>Location</h3>
+          <p>Denpasar, Bali</p>
+        </div>
+        <div class="logistics-card">
+          <h3>Timezone</h3>
+          <p>UTC+8</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>© <span id="year"></span> Putu Astika — Built with hand‑crafted HTML, CSS, and JS.</p>
+  </footer>
+
+  <script src="assets/js/script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,92 +3,107 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Putu Astika — Portfolio</title>
+  <title>Putu Astika — Builder, Operator, Problem-solver.</title>
   <meta name="description" content="Putu Astika • Builder, Operator, Problem-solver. Lean web, responsible AI, and ops systems." />
   <link rel="stylesheet" href="/assets/css/styles.css" />
-  <link rel="icon" href="assets/profile.png" type="image/svg+xml">
-  <meta property="og:title" content="Putu Astika — Portfolio" />
+  <link rel="icon" href="assets/profile.png" type="image/png" />
+  <meta property="og:title" content="Putu Astika — Builder, Operator, Problem-solver." />
   <meta property="og:description" content="Builder, Operator, Problem-solver. Lean web, responsible AI, and ops systems." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="assets/og-image.png" />
   <meta property="og:url" content="https://astika.is-a.dev" />
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
 </head>
-<body>
+<body data-page="home">
   <a class="skip-link" href="#main-content">Skip to main content</a>
   <div id="top" aria-hidden="true"></div>
-  <!-- Fixed, always-on-top navbar -->
-  <header id="site-header" class="header">
-    <nav id="navbar" class="nav" aria-label="Primary">
-      <a class="brand" href="#top" aria-label="Homepage" title="Putu Astika">
-        <img src="assets/profile.png" alt="PA logo" width="28" height="28" />
+
+  <header class="site-header" data-nav>
+    <nav class="nav" aria-label="Primary">
+      <a class="nav__brand" href="index.html" aria-label="Homepage" title="Putu Astika">
+        <img src="assets/profile.png" alt="PA logo" width="32" height="32" />
+        <span class="nav__brand-text">Putu Astika</span>
       </a>
-      <button class="nav-toggle" aria-controls="nav-links" aria-expanded="false" aria-label="Toggle navigation">☰</button>
-      <div id="nav-links" class="nav-links">
-        <a class="nav-link" href="#about">About</a>
-        <a class="nav-link" href="#skills">Skills</a>
-        <a class="nav-link" href="#projects">Projects</a>
-        <a class="nav-link" href="#certs">Certificates</a>
-        <a class="nav-link" href="#contact">Contact</a>
-        <a class="nav-link" href="#resume">Resume</a>
-        <!-- External link to Bali WebDeveloper -->
-        <a class="nav-link external" href="https://astika327-dev.github.io/bali-webdeveloper/index.html" target="_blank" rel="noopener">Bali WebDeveloper ↗</a>
+      <button class="nav__toggle" type="button" aria-controls="nav-menu" aria-expanded="false" aria-label="Toggle navigation" data-nav-toggle>
+        <span aria-hidden="true">☰</span>
+      </button>
+      <div class="nav__menu" id="nav-menu" data-nav-menu>
+        <a class="nav__link" href="index.html" data-page-link="home">Home</a>
+        <a class="nav__link" href="work.html" data-page-link="work">Work</a>
+        <a class="nav__link" href="skills.html" data-page-link="skills resume">Skills</a>
+        <a class="nav__link" href="about.html" data-page-link="about">About</a>
+        <a class="nav__link" href="contact.html" data-page-link="contact">Contact</a>
+        <a class="nav__link nav__link--external" href="https://astika327-dev.github.io/bali-webdeveloper/index.html" target="_blank" rel="noopener">Bali WebDeveloper ↗</a>
+        <a class="nav__cta" href="skills.html#resume" data-page-link="skills resume">Resume</a>
       </div>
     </nav>
   </header>
 
   <main id="main-content" tabindex="-1">
-    <!-- Hero / Welcome (full viewport height) -->
-    <section id="welcome" class="hero" aria-label="Welcome section">
-      <h1 class="hero-title">Builder, Operator,<br/> Problem‑solver.</h1>
-      <p class="hero-sub">I turn messy problems into clean systems—lean web, responsible AI, and ops tooling.</p>
-      <div class="hero-actions">
-        <a class="btn primary" href="#projects">See Projects</a>
-        <a class="btn ghost" href="#contact">Get in Touch</a>
+    <section class="hero">
+      <div class="hero__text">
+        <p class="eyebrow">Ops-first generalist</p>
+        <h1 class="hero__title">Builder, Operator,<br />Problem‑solver.</h1>
+        <p class="hero__lead">I turn messy problems into clean systems—lean web, responsible AI, and ops tooling.</p>
+        <div class="hero__actions">
+          <a class="btn btn--primary" href="work.html">See projects</a>
+          <a class="btn btn--ghost" href="contact.html">Get in touch</a>
+        </div>
+        <dl class="hero__meta">
+          <div class="meta-item">
+            <dt>Availability</dt>
+            <dd>Available for work</dd>
+          </div>
+          <div class="meta-item">
+            <dt>Location</dt>
+            <dd>Bali (UTC+8)</dd>
+          </div>
+        </dl>
       </div>
-      <div class="hero-meta">Available for work • Bali (UTC+8)</div>
+      <div class="hero__panel">
+        <div class="panel-card">
+          <h2>About</h2>
+          <p>Ops‑first generalist with a content background who builds small, durable web tools.</p>
+          <ul class="panel-list">
+            <li>Ships fast with clear acceptance criteria</li>
+            <li>Prefers simplicity over ceremony</li>
+            <li>Writes docs and checklists people actually use</li>
+          </ul>
+        </div>
+      </div>
     </section>
 
-    <!-- About -->
-    <section id="about" class="section">
-      <h2>About</h2>
-      <p>Ops‑first generalist with a content background who builds small, durable web tools. I optimize workflows, document knowledge, and ship pragmatic features—preferably with simple tech that’s easy to maintain.</p>
-      <ul class="bullets">
-        <li>Ships fast with clear acceptance criteria</li>
-        <li>Prefers simplicity over ceremony</li>
-        <li>Writes docs and checklists people actually use</li>
-      </ul>
-    </section>
-
-    <!-- Skills -->
-    <section id="skills" class="section">
-      <h2>Skills</h2>
-      <div class="cards three">
-        <article class="card">
+    <section class="section" aria-labelledby="focus-heading">
+      <div class="section__header">
+        <h2 id="focus-heading">Core disciplines</h2>
+        <p class="section__lede">Lean web builds, responsible AI usage, and operations systems that keep teams calm and productive.</p>
+      </div>
+      <div class="card-grid card-grid--three">
+        <article class="card card--focus">
           <h3>Web</h3>
           <ul>
             <li>Semantic HTML</li>
             <li>Modern CSS (Flex/Grid, variables)</li>
             <li>Basic JS (DOM, fetch, modules)</li>
-            <li>Git & GitHub Pages</li>
+            <li>Git &amp; GitHub Pages</li>
           </ul>
         </article>
-        <article class="card">
+        <article class="card card--focus">
           <h3>AI</h3>
           <ul>
             <li>Prompt design systems</li>
-            <li>Review & evaluation loops</li>
-            <li>Grounding & fact‑checking discipline</li>
+            <li>Review &amp; evaluation loops</li>
+            <li>Grounding &amp; fact‑checking discipline</li>
             <li>Workflow automation ideas</li>
           </ul>
         </article>
-        <article class="card">
-          <h3>Soft & Tools</h3>
+        <article class="card card--focus">
+          <h3>Soft &amp; Tools</h3>
           <ul>
             <li>Clarity, bias to action</li>
-            <li>Ownership & follow‑through</li>
+            <li>Ownership &amp; follow‑through</li>
             <li>Figma/Canva, Notion, Google Suite</li>
             <li>Chrome DevTools, VS Code</li>
           </ul>
@@ -96,100 +111,75 @@
       </div>
     </section>
 
-    <!-- Projects -->
-    <section id="projects" class="section">
-      <h2>Projects</h2>
-      <div class="cards three">
-        <article class="card project">
-          <div class="project-head">
-            <h3>PromptCraft</h3>
-            <span class="tag">AI & Writing</span>
-          </div>
-          <p>Prompt builder with reusable patterns and an audit‑friendly preview.</p>
-          <div class="actions">
-            <a class="btn" href="https://astika327-dev.github.io/promptcraft/" target="_blank" rel="noopener">Live</a>
-            <a class="btn ghost" href="https://github.com/astika327-dev/promptcraft" target="_blank" rel="noopener">Source</a>
-          </div>
-        </article>
-        <article class="card project">
-          <div class="project-head">
-            <h3>Ops Playbook</h3>
-            <span class="tag">Ops Systems</span>
-          </div>
-          <p>Unified SOP/QA kit: checklists, incident notes, and audit templates.</p>
-          <div class="actions">
-            <a class="btn" href="https://astika327-dev.github.io/opsplaybook-hospitality/" target="_blank" rel="noopener">Live</a>
-            <a class="btn ghost" href="https://github.com/astika327-dev/opsplaybook-hospitality" target="_blank" rel="noopener">Source</a>
+    <section class="section" aria-labelledby="projects-heading">
+      <div class="section__header">
+        <h2 id="projects-heading">Featured work</h2>
+        <p class="section__lede">A sample of purpose-built tools spanning AI guidance, hospitality operations, and utility scripts.</p>
+      </div>
+      <div class="project-grid">
+        <article class="project-card">
+          <img class="project-card__media" src="assets/pcimage.png" alt="PromptCraft interface preview" loading="lazy" />
+          <div class="project-card__body">
+            <div class="project-card__top">
+              <h3>PromptCraft</h3>
+              <span class="project-card__tag">AI &amp; Writing</span>
+            </div>
+            <p>Prompt builder with reusable patterns and an audit‑friendly preview.</p>
+            <div class="project-card__actions">
+              <a class="btn btn--primary" href="https://astika327-dev.github.io/promptcraft/" target="_blank" rel="noopener">Live</a>
+              <a class="btn btn--ghost" href="https://github.com/astika327-dev/promptcraft" target="_blank" rel="noopener">Source</a>
+            </div>
           </div>
         </article>
-        <article class="card project">
-          <div class="project-head">
-            <h3>Mini‑Tools</h3>
-            <span class="tag">Web Utils</span>
+        <article class="project-card">
+          <img class="project-card__media" src="assets/opsplaybookimage.png" alt="Ops Playbook checklists preview" loading="lazy" />
+          <div class="project-card__body">
+            <div class="project-card__top">
+              <h3>Ops Playbook</h3>
+              <span class="project-card__tag">Ops Systems</span>
+            </div>
+            <p>Unified SOP/QA kit: checklists, incident notes, and audit templates.</p>
+            <div class="project-card__actions">
+              <a class="btn btn--primary" href="https://astika327-dev.github.io/opsplaybook-hospitality/" target="_blank" rel="noopener">Live</a>
+              <a class="btn btn--ghost" href="https://github.com/astika327-dev/opsplaybook-hospitality" target="_blank" rel="noopener">Source</a>
+            </div>
           </div>
-          <p>Small JS utilities: quote calculator, SOP printer, and name helper.</p>
-          <div class="actions">
-            <a class="btn" href="https://astika327-dev.github.io/minitools/" target="_blank" rel="noopener">Live</a>
-            <a class="btn ghost" href="https://github.com/astika327-dev/minitools" target="_blank" rel="noopener">Source</a>
+        </article>
+        <article class="project-card">
+          <img class="project-card__media" src="assets/minitoolsimage.png" alt="Mini-Tools preview" loading="lazy" />
+          <div class="project-card__body">
+            <div class="project-card__top">
+              <h3>Mini‑Tools</h3>
+              <span class="project-card__tag">Web Utils</span>
+            </div>
+            <p>Small JS utilities: quote calculator, SOP printer, and name helper.</p>
+            <div class="project-card__actions">
+              <a class="btn btn--primary" href="https://astika327-dev.github.io/minitools/" target="_blank" rel="noopener">Live</a>
+              <a class="btn btn--ghost" href="https://github.com/astika327-dev/minitools" target="_blank" rel="noopener">Source</a>
+            </div>
           </div>
         </article>
       </div>
-      <div class="note ext">
-        Also see <a href="https://astika327-dev.github.io/bali-webdeveloper/index.html" target="_blank" rel="noopener">Bali WebDeveloper ↗</a> for the business site.
-      </div>
-    </section>
-
-    <!-- Certificates -->
-    <section id="certs" class="section">
-      <h2>Certificates</h2>
-      <div class="cards two">
-        <article class="card cert">
-          <h3>freeCodeCamp — Responsive Web Design</h3>
-          <p>Projects: Survey Form, Tribute Page, Technical Docs, Product Landing, Portfolio.</p>
-          <a class="btn" href="https://www.freecodecamp.org/certification/astika/responsive-web-design" target="_blank" rel="noopener">View Credential</a>
-        </article>
-        <article class="card cert">
-          <h3>freeCodeCamp — Front End Development Libraries</h3>
-          <p>React components, state management basics, and UI libraries.</p>
-          <a class="btn" href="https://www.freecodecamp.org/certification/astika/front-end-development-libraries" target="_blank" rel="noopener">View Credential</a>
-        </article>
+      <div class="section__footer">
+        <a class="link-arrow" href="work.html">Explore the full case studies ↗</a>
       </div>
     </section>
 
-    <!-- Contact -->
-    <section id="contact" class="section">
-      <h2>Contact</h2>
-      <p>Short message, clear ask. Open for freelance and collaboration.</p>
-      <div class="actions">
-        <a class="btn ghost" href="mailto:astika327@gmail.com">Email</a>
-        <a class="btn ghost" href="https://wa.me/6282146178461" target="_blank" rel="noopener">WhatsApp</a>
-        <a id="profile-link" class="btn ghost" href="https://github.com/astika327-dev" target="_blank" rel="noopener">GitHub</a>
-      </div>
-      <div class="small muted">Location: Denpasar, Bali • Timezone: UTC+8</div>
-    </section>
-
-    <!-- Resume -->
-    <section id="resume" class="section">
-      <h2>Resume</h2>
-      <p>One page. Results only.</p>
-      <div class="actions">
-        <a class="btn ghost" href="assets/Putu-Astika-Resume.pdf" target="_blank" rel="noopener">View PDF</a>
-        <button class="btn ghost" data-print>Print</button>
-        <button class="btn ghost" data-share>Share</button>
-      </div>
-      <div class="resume-mini card">
-        <h3>Summary</h3>
-        <ul>
-          <li>Junior Web Developer (HTML, CSS, basic JS)</li>
-          <li>Responsible AI user (prompt design, review loops)</li>
-          <li>Ops background with strong problem‑solving</li>
-        </ul>
+    <section class="cta">
+      <div class="cta__content">
+        <h2>Ready to brief?</h2>
+        <p>Short message, clear ask. Open for freelance and collaboration.</p>
+        <div class="cta__actions">
+          <a class="btn btn--ghost" href="mailto:astika327@gmail.com">Email</a>
+          <a class="btn btn--ghost" href="https://wa.me/6282146178461" target="_blank" rel="noopener">WhatsApp</a>
+          <a class="btn btn--ghost" href="https://github.com/astika327-dev" target="_blank" rel="noopener" id="profile-link">GitHub</a>
+        </div>
       </div>
     </section>
   </main>
 
-  <footer class="footer">
-    <p>© <span id="year"></span> Putu Astika — Built with hand‑crafted HTML/CSS/JS.</p>
+  <footer class="site-footer">
+    <p>© <span id="year"></span> Putu Astika — Built with hand‑crafted HTML, CSS, and JS.</p>
   </footer>
 
   <script src="assets/js/script.js"></script>

--- a/skills.html
+++ b/skills.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Skills — Putu Astika</title>
+  <meta name="description" content="Skills, certificates, and resume for Putu Astika." />
+  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="assets/profile.png" type="image/png" />
+  <meta property="og:title" content="Skills — Putu Astika" />
+  <meta property="og:description" content="Skills, certificates, and resume for Putu Astika." />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="assets/og-image.png" />
+  <meta property="og:url" content="https://astika.is-a.dev/skills.html" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+</head>
+<body data-page="skills">
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <div id="top" aria-hidden="true"></div>
+
+  <header class="site-header" data-nav>
+    <nav class="nav" aria-label="Primary">
+      <a class="nav__brand" href="index.html" aria-label="Homepage" title="Putu Astika">
+        <img src="assets/profile.png" alt="PA logo" width="32" height="32" />
+        <span class="nav__brand-text">Putu Astika</span>
+      </a>
+      <button class="nav__toggle" type="button" aria-controls="nav-menu" aria-expanded="false" aria-label="Toggle navigation" data-nav-toggle>
+        <span aria-hidden="true">☰</span>
+      </button>
+      <div class="nav__menu" id="nav-menu" data-nav-menu>
+        <a class="nav__link" href="index.html" data-page-link="home">Home</a>
+        <a class="nav__link" href="work.html" data-page-link="work">Work</a>
+        <a class="nav__link" href="skills.html" data-page-link="skills resume">Skills</a>
+        <a class="nav__link" href="about.html" data-page-link="about">About</a>
+        <a class="nav__link" href="contact.html" data-page-link="contact">Contact</a>
+        <a class="nav__link nav__link--external" href="https://astika327-dev.github.io/bali-webdeveloper/index.html" target="_blank" rel="noopener">Bali WebDeveloper ↗</a>
+        <a class="nav__cta" href="#resume" data-page-link="skills resume">Resume</a>
+      </div>
+    </nav>
+  </header>
+
+  <main id="main-content" tabindex="-1">
+    <section class="page-hero">
+      <p class="eyebrow">Skills</p>
+      <h1>Lean web development, responsible AI practice, and the operations toolkit that keeps projects stable.</h1>
+      <p>This stack keeps delivery fast without sacrificing clarity or documentation.</p>
+    </section>
+
+    <section class="section" aria-labelledby="skills-heading">
+      <div class="section__header">
+        <h2 id="skills-heading">Capabilities</h2>
+        <p class="section__lede">The triad that appears in every engagement: web, AI enablement, and the tools that keep teams in sync.</p>
+      </div>
+      <div class="card-grid card-grid--three">
+        <article class="card card--focus">
+          <h3>Web</h3>
+          <ul>
+            <li>Semantic HTML</li>
+            <li>Modern CSS (Flex/Grid, variables)</li>
+            <li>Basic JS (DOM, fetch, modules)</li>
+            <li>Git &amp; GitHub Pages</li>
+          </ul>
+        </article>
+        <article class="card card--focus">
+          <h3>AI</h3>
+          <ul>
+            <li>Prompt design systems</li>
+            <li>Review &amp; evaluation loops</li>
+            <li>Grounding &amp; fact‑checking discipline</li>
+            <li>Workflow automation ideas</li>
+          </ul>
+        </article>
+        <article class="card card--focus">
+          <h3>Soft &amp; Tools</h3>
+          <ul>
+            <li>Clarity, bias to action</li>
+            <li>Ownership &amp; follow‑through</li>
+            <li>Figma/Canva, Notion, Google Suite</li>
+            <li>Chrome DevTools, VS Code</li>
+          </ul>
+        </article>
+      </div>
+    </section>
+
+    <section class="section" aria-labelledby="cert-heading">
+      <div class="section__header">
+        <h2 id="cert-heading">Certificates</h2>
+        <p class="section__lede">Structured learning that backs the daily practice.</p>
+      </div>
+      <div class="card-grid card-grid--two">
+        <article class="card card--cert">
+          <h3>freeCodeCamp — Responsive Web Design</h3>
+          <p>Projects: Survey Form, Tribute Page, Technical Docs, Product Landing, Portfolio.</p>
+          <a class="btn btn--ghost" href="https://www.freecodecamp.org/certification/astika/responsive-web-design" target="_blank" rel="noopener">View credential</a>
+        </article>
+        <article class="card card--cert">
+          <h3>freeCodeCamp — Front End Development Libraries</h3>
+          <p>React components, state management basics, and UI libraries.</p>
+          <a class="btn btn--ghost" href="https://www.freecodecamp.org/certification/astika/front-end-development-libraries" target="_blank" rel="noopener">View credential</a>
+        </article>
+      </div>
+    </section>
+
+    <section class="section section--highlight" id="resume" aria-labelledby="resume-heading">
+      <div class="section__header">
+        <h2 id="resume-heading">Resume snapshot</h2>
+        <p class="section__lede">One page. Results only.</p>
+      </div>
+      <div class="resume-panel">
+        <div class="resume-panel__body">
+          <h3>Summary</h3>
+          <ul>
+            <li>Junior Web Developer (HTML, CSS, basic JS)</li>
+            <li>Responsible AI user (prompt design, review loops)</li>
+            <li>Ops background with strong problem‑solving</li>
+          </ul>
+        </div>
+        <div class="resume-panel__actions">
+          <a class="btn btn--primary" href="assets/Putu-Astika-Resume.pdf" target="_blank" rel="noopener">View PDF</a>
+          <button class="btn btn--ghost" type="button" data-print>Print</button>
+          <button class="btn btn--ghost" type="button" data-share>Share</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="cta">
+      <div class="cta__content">
+        <h2>Let’s collaborate</h2>
+        <p>Short message, clear ask. Open for freelance and collaboration.</p>
+        <div class="cta__actions">
+          <a class="btn btn--ghost" href="mailto:astika327@gmail.com">Email</a>
+          <a class="btn btn--ghost" href="https://wa.me/6282146178461" target="_blank" rel="noopener">WhatsApp</a>
+          <a class="btn btn--ghost" href="https://github.com/astika327-dev" target="_blank" rel="noopener">GitHub</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>© <span id="year"></span> Putu Astika — Built with hand‑crafted HTML, CSS, and JS.</p>
+  </footer>
+
+  <script src="assets/js/script.js"></script>
+</body>
+</html>

--- a/work.html
+++ b/work.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Work — Putu Astika</title>
+  <meta name="description" content="Project portfolio featuring PromptCraft, Ops Playbook, and Mini-Tools by Putu Astika." />
+  <link rel="stylesheet" href="/assets/css/styles.css" />
+  <link rel="icon" href="assets/profile.png" type="image/png" />
+  <meta property="og:title" content="Work — Putu Astika" />
+  <meta property="og:description" content="Project portfolio featuring PromptCraft, Ops Playbook, and Mini-Tools by Putu Astika." />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="assets/og-image.png" />
+  <meta property="og:url" content="https://astika.is-a.dev/work.html" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+</head>
+<body data-page="work">
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <div id="top" aria-hidden="true"></div>
+
+  <header class="site-header" data-nav>
+    <nav class="nav" aria-label="Primary">
+      <a class="nav__brand" href="index.html" aria-label="Homepage" title="Putu Astika">
+        <img src="assets/profile.png" alt="PA logo" width="32" height="32" />
+        <span class="nav__brand-text">Putu Astika</span>
+      </a>
+      <button class="nav__toggle" type="button" aria-controls="nav-menu" aria-expanded="false" aria-label="Toggle navigation" data-nav-toggle>
+        <span aria-hidden="true">☰</span>
+      </button>
+      <div class="nav__menu" id="nav-menu" data-nav-menu>
+        <a class="nav__link" href="index.html" data-page-link="home">Home</a>
+        <a class="nav__link" href="work.html" data-page-link="work">Work</a>
+        <a class="nav__link" href="skills.html" data-page-link="skills resume">Skills</a>
+        <a class="nav__link" href="about.html" data-page-link="about">About</a>
+        <a class="nav__link" href="contact.html" data-page-link="contact">Contact</a>
+        <a class="nav__link nav__link--external" href="https://astika327-dev.github.io/bali-webdeveloper/index.html" target="_blank" rel="noopener">Bali WebDeveloper ↗</a>
+        <a class="nav__cta" href="skills.html#resume" data-page-link="skills resume">Resume</a>
+      </div>
+    </nav>
+  </header>
+
+  <main id="main-content" tabindex="-1">
+    <section class="page-hero">
+      <p class="eyebrow">Work</p>
+      <h1>Lean products and ops tooling built to keep delivery predictable.</h1>
+      <p>Each project here balances speed, documentation, and pragmatic feature sets so teams can keep momentum without overbuilt systems.</p>
+    </section>
+
+    <section class="section project-section" aria-labelledby="promptcraft-heading">
+      <div class="project-layout">
+        <div class="project-layout__media">
+          <img src="assets/pcimage.png" alt="PromptCraft interface preview" loading="lazy" />
+        </div>
+        <div class="project-layout__content">
+          <p class="eyebrow">AI &amp; Writing</p>
+          <h2 id="promptcraft-heading">PromptCraft</h2>
+          <p>Prompt builder with reusable patterns and an audit‑friendly preview.</p>
+          <ul class="feature-list">
+            <li>Reusable prompt modules so writers stay consistent.</li>
+            <li>Preview pane mirrors the final output for quick reviews.</li>
+            <li>Versioned templates to support audit trails and iterations.</li>
+          </ul>
+          <div class="project-card__actions">
+            <a class="btn btn--primary" href="https://astika327-dev.github.io/promptcraft/" target="_blank" rel="noopener">Live</a>
+            <a class="btn btn--ghost" href="https://github.com/astika327-dev/promptcraft" target="_blank" rel="noopener">Source</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section project-section" aria-labelledby="opsplaybook-heading">
+      <div class="project-layout project-layout--flip">
+        <div class="project-layout__media">
+          <img src="assets/opsplaybookimage.png" alt="Ops Playbook checklists preview" loading="lazy" />
+        </div>
+        <div class="project-layout__content">
+          <p class="eyebrow">Ops Systems</p>
+          <h2 id="opsplaybook-heading">Ops Playbook</h2>
+          <p>Unified SOP/QA kit: checklists, incident notes, and audit templates.</p>
+          <ul class="feature-list">
+            <li>Centralized SOP library with printable checklists.</li>
+            <li>Incident capture that keeps context for follow-ups.</li>
+            <li>Audit templates to make compliance reviews painless.</li>
+          </ul>
+          <div class="project-card__actions">
+            <a class="btn btn--primary" href="https://astika327-dev.github.io/opsplaybook-hospitality/" target="_blank" rel="noopener">Live</a>
+            <a class="btn btn--ghost" href="https://github.com/astika327-dev/opsplaybook-hospitality" target="_blank" rel="noopener">Source</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section project-section" aria-labelledby="minitools-heading">
+      <div class="project-layout">
+        <div class="project-layout__media">
+          <img src="assets/minitoolsimage.png" alt="Mini-Tools preview" loading="lazy" />
+        </div>
+        <div class="project-layout__content">
+          <p class="eyebrow">Web Utils</p>
+          <h2 id="minitools-heading">Mini‑Tools</h2>
+          <p>Small JS utilities: quote calculator, SOP printer, and name helper.</p>
+          <ul class="feature-list">
+            <li>Lightweight utilities for quick on-the-floor decisions.</li>
+            <li>Focused UI that runs on any device without setup.</li>
+            <li>Print-friendly outputs for teams that need hard copies.</li>
+          </ul>
+          <div class="project-card__actions">
+            <a class="btn btn--primary" href="https://astika327-dev.github.io/minitools/" target="_blank" rel="noopener">Live</a>
+            <a class="btn btn--ghost" href="https://github.com/astika327-dev/minitools" target="_blank" rel="noopener">Source</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="cta">
+      <div class="cta__content">
+        <h2>Have a project in mind?</h2>
+        <p>Short message, clear ask. Open for freelance and collaboration.</p>
+        <div class="cta__actions">
+          <a class="btn btn--ghost" href="mailto:astika327@gmail.com">Email</a>
+          <a class="btn btn--ghost" href="https://wa.me/6282146178461" target="_blank" rel="noopener">WhatsApp</a>
+          <a class="btn btn--ghost" href="https://github.com/astika327-dev" target="_blank" rel="noopener">GitHub</a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>© <span id="year"></span> Putu Astika — Built with hand‑crafted HTML, CSS, and JS.</p>
+  </footer>
+
+  <script src="assets/js/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- redesign the portfolio into a multi-page experience with dedicated Work, Skills, About, and Contact views
- introduce a refreshed visual system, responsive layout primitives, and accessible navigation with mobile focus trapping
- retain existing personal data across new sections while expanding project storytelling and resume access

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d14f1a2d5483239a494a12a82c1725